### PR TITLE
Correct bug in kovats_retention_index.R

### DIFF
--- a/R/kovats_retention_index.R
+++ b/R/kovats_retention_index.R
@@ -124,6 +124,14 @@ kovats_retention_index <- function(filtered_data, std.info) {
           filter(get("mean_RT") >= rt) |>
           filter(get("Class") == "Alkane")
 
+          # print("previous alkane:")
+          # print(prev_alkane)
+          # 
+          # print("next alkane:")
+          # print(next.alka)
+
+        # If there is an alkane after the target peak, RI is calculated.
+        # If not, then RI is equal to RI of previous alkane + RT of target peak
         if(next.alka |> nrow() > 0) {
           next.alka <- next.alka |>
             filter(get("Chain.length") == min(next.alka[["Chain.length"]]))
@@ -137,7 +145,9 @@ kovats_retention_index <- function(filtered_data, std.info) {
           # Round up the RI to make it an integer
           retention_index <- retention_index |> round(digits = 0)
         } else {
-          retention_index <- ri_list[[length(ri_list)]] + rt
+          retention_index <- (prev_alkane |> 
+                                  filter(get("Chain.length") == max(prev_alkane[["Chain.length"]])) |> 
+                                  pull("Chain.length") * 100) + rt
         }
 
         # Store the RI in ri_list


### PR DESCRIPTION
There was a bug with the function, some of the last compounds were getting a RI lower than that of the alkane before them. This was happening because the correction for the calculation of the RI for peaks with no alkane after them was adding the RT of the target peak to the RI of the last compound for which a RI was calculated. Therefore, in cases where the last compound for which the RI was calculated had a RT lower than the alkane before the target compound (i.e. the alkane is not in the samples, but in the standards), the RT of the target peak was being summed to the RI of a peak that eluded before the alkane that would precede the target peak. 

Now, if there is no alkane after the target peak, the RI of the target peak is calculated as the sum between the RI of previous the alkane and the RT of the target peak.